### PR TITLE
Fix #27 by using Core.Compiler instead of Core.Inference on v0.7

### DIFF
--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -97,7 +97,9 @@ macro memoize(args...)
              getfield(mod, fcachename):
              eval(mod, :(const $fcachename = ($dicttype)()))
 
-    if length(kws) == 0 && VERSION >= v"0.5.0-dev+5235"
+    if length(kws) == 0 && VERSION >= v"0.7.0-alpha.0"
+        lookup = :($fcache[($(tup...),)]::Core.Compiler.return_type($u, typeof(($(identargs...),))))
+    elseif length(kws) == 0 && VERSION >= v"0.5.0-dev+5235"
         lookup = :($fcache[($(tup...),)]::Core.Inference.return_type($u, typeof(($(identargs...),))))
     else
         lookup = :($fcache[($(tup...),)])


### PR DESCRIPTION
Here is a quick workaround for issue #27.

There is probably a better solution, but at least this fixes the issue.